### PR TITLE
[#97630680] Tsuru healthcheck config for JAR

### DIFF
--- a/target/tsuru.yaml
+++ b/target/tsuru.yaml
@@ -1,0 +1,2 @@
+healthcheck:
+  path: /healthcheck


### PR DESCRIPTION
I added this to the root of the repo in 2fb4d0b but that isn't used when
deploying the application from a JAR with `tsuru app-deploy`. We can't
symlink the file like we did in c4b77ae because we don't want the `hooks`
section, so we have to create a separate copy.

---

```
➜  example-java-jetty git:(tsuru_healthcheck_jar) tsuru app-deploy -a example-java-jetty target
Uploading files......... ok
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)

---- Building application image ----
 ---> Sending image to repository (1.00MB)
 ---> Cleaning up

---- Starting 1 new unit ----
 ---> Started unit 8186416bb1...

---- Binding and checking 1 new units ----
 ---> healthcheck fail(8186416bb1): Get http://10.128.11.168:32795/healthcheck: dial tcp 10.128.11.168:32795: connection refused. Trying again in 3s
 ---> healthcheck successful(8186416bb1)
 ---> Bound and checked unit 8186416bb1

---- Adding routes to 1 new units ----
 ---> Added route to unit 8186416bb1

---- Removing routes from 1 old units ----
 ---> Removed route from unit a6f6b43e18

---- Removing 1 old unit ----
 ---> Removed old unit a6f6b43e18...

---- Unbinding 1 old unit ----
 ---> Removed bind for old unit a6f6b43e18...

OK
```