### PR TITLE
[#98651476] Fix app-deploy of example-java-jetty

### DIFF
--- a/target/Procfile
+++ b/target/Procfile
@@ -1,1 +1,1 @@
-../Procfile
+web: java -cp helloworld-1.0-SNAPSHOT.jar:dependency/* HelloWorld


### PR DESCRIPTION
The deployment in our Tsuru is slightly different than the original Deis app because the classpath in the original Procfile refers to the target directory.
But we pre compile the application in the target directory and since we deploy with `tsuru app-deploy target -a <app_name>`,  we send only the *content* of the "target" directory. Therefore the classpath must refer to the current directory instead.
This PR only alters the Procfile in the target directory. For completeness the whole thing should be generated via Maven but this is out of scope for the demo.

**Who should review**
Anyone but @saliceti

**How to review**
```bash
$ tsuru app-create java1 java
App "java1" has been created!
Use app-info to check the status of the app and its units.
Your repository for "java1" project is "git@demo-gandalf.tsuru.paas.alphagov.co.uk:java1.git"

$ tsuru app-deploy target -a java1
Uploading files...... ok
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
[...]
---- Adding routes to 1 new units ----
 ---> Added route to unit 9ab9e2e14a

OK
```
